### PR TITLE
Fixed Templates/nginx-image-builder.yml and AnsibleConfig/component-nginx.yml

### DIFF
--- a/AnsibleConfig/component-nginx.yml
+++ b/AnsibleConfig/component-nginx.yml
@@ -6,7 +6,7 @@ schemaVersion: 1.0
 constants:
   - s3bucket:
       type: string
-      value: <input_s3_bucket_name> # <-- REPLACE VALUE HERE WITH S3 BUCKET NAME 
+      value: <input_s3_bucket_name> # <-- REPLACE VALUE HERE WITH S3 BUCKET NAME
 phases:
   - name: build
     steps:

--- a/AnsibleConfig/component-nginx.yml
+++ b/AnsibleConfig/component-nginx.yml
@@ -19,8 +19,8 @@ phases:
         action: ExecuteBash
         inputs:
           commands:
-            - sudo mkdir -p /ansibleloc/roles/LinuxCis #Fixed, added parent file for role to work
-            - sudo mkdir -p /ansibleloc/roles/Nginx  #Fixed, added parent file for role to work
+            - sudo mkdir -p /ansibleloc/roles/LinuxCis
+            - sudo mkdir -p /ansibleloc/roles/Nginx
       - name: DownloadLinuxCis
         action: S3Download
         inputs:
@@ -30,7 +30,7 @@ phases:
         action: ExecuteBash
         inputs:
           commands:
-            - unzip /ansibleloc/linux-cis.zip -d /ansibleloc/roles/LinuxCis #Fixed, added destination to unpack files to corresponding role folder
+            - unzip /ansibleloc/linux-cis.zip -d /ansibleloc/roles/LinuxCis
             - echo "unzip linux-cis file"
       - name: DownloadCisPlaybook
         action: S3Download
@@ -58,7 +58,7 @@ phases:
         action: ExecuteBash
         inputs:
           commands:
-            - unzip /ansibleloc/nginx.zip -d /ansibleloc/roles/Nginx #Fixed, added destination to unpack files to corresponding role folder
+            - unzip /ansibleloc/nginx.zip -d /ansibleloc/roles/Nginx
             - echo "unzip Nginx file"
       - name: DownloadNginxPlaybook
         action: S3Download

--- a/AnsibleConfig/component-nginx.yml
+++ b/AnsibleConfig/component-nginx.yml
@@ -19,8 +19,7 @@ phases:
         action: ExecuteBash
         inputs:
           commands:
-            - sudo mkdir -p /ansibleloc/roles/LinuxCis
-            - sudo mkdir -p /ansibleloc/roles/Nginx
+            - sudo mkdir -p /ansibleloc/roles/LinuxCis /ansibleloc/roles/Nginx
       - name: DownloadLinuxCis
         action: S3Download
         inputs:

--- a/AnsibleConfig/component-nginx.yml
+++ b/AnsibleConfig/component-nginx.yml
@@ -6,7 +6,7 @@ schemaVersion: 1.0
 constants:
   - s3bucket:
       type: string
-      value: <input_s3_bucket_name> # <-- REPLACE VALUE HERE WITH S3 BUCKET NAME
+      value: <input_s3_bucket_name> # <-- REPLACE VALUE HERE WITH S3 BUCKET NAME 
 phases:
   - name: build
     steps:
@@ -19,7 +19,8 @@ phases:
         action: ExecuteBash
         inputs:
           commands:
-            - sudo mkdir -p /ansibleloc/roles
+            - sudo mkdir -p /ansibleloc/roles/LinuxCis #Fixed, added parent file for role to work
+            - sudo mkdir -p /ansibleloc/roles/Nginx  #Fixed, added parent file for role to work
       - name: DownloadLinuxCis
         action: S3Download
         inputs:
@@ -29,7 +30,7 @@ phases:
         action: ExecuteBash
         inputs:
           commands:
-            - unzip /ansibleloc/linux-cis.zip -d /ansibleloc/roles
+            - unzip /ansibleloc/linux-cis.zip -d /ansibleloc/roles/LinuxCis #Fixed, added destination to unpack files to corresponding role folder
             - echo "unzip linux-cis file"
       - name: DownloadCisPlaybook
         action: S3Download
@@ -57,7 +58,7 @@ phases:
         action: ExecuteBash
         inputs:
           commands:
-            - unzip /ansibleloc/nginx.zip -d /ansibleloc/roles
+            - unzip /ansibleloc/nginx.zip -d /ansibleloc/roles/Nginx #Fixed, added destination to unpack files to corresponding role folder
             - echo "unzip Nginx file"
       - name: DownloadNginxPlaybook
         action: S3Download

--- a/Templates/nginx-image-builder.yml
+++ b/Templates/nginx-image-builder.yml
@@ -167,7 +167,7 @@ Resources:
         ImageTestsEnabled: false
         TimeoutMinutes: 60
       Schedule:
-        ScheduleExpression: 'cron(0 0 1 * *)'
+        ScheduleExpression: 'cron(0 0 1 * ? *)'
         PipelineExecutionStartCondition: 'EXPRESSION_MATCH_ONLY'
 
 # Uncomment this block if you want an initial AMI to be created during Stack Creation


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Updated the cron expression with the wildcard **'?'** as mentioned in the AWS documentation, this allows for the successful creation of the cis-image-builder stack.
- Added the creation of the roles directories **LinuxCis** and **Nginx** respectively. Unpacking of the files goes directly to each role directory in order for proper functionality of the Ansible playbook within the EC2 Amazon instance.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
