### PR TITLE
Updating S3 Bucket to enable versioning and enforce TLS encryption on…

### DIFF
--- a/Templates/nginx-image-builder.yml
+++ b/Templates/nginx-image-builder.yml
@@ -167,7 +167,7 @@ Resources:
         ImageTestsEnabled: false
         TimeoutMinutes: 60
       Schedule:
-        ScheduleExpression: 'cron(0 0 1 * *)'
+        ScheduleExpression: cron(0 5 1 * ? *)
         PipelineExecutionStartCondition: 'EXPRESSION_MATCH_ONLY'
 
 # Uncomment this block if you want an initial AMI to be created during Stack Creation

--- a/Templates/s3-iam-config.yml
+++ b/Templates/s3-iam-config.yml
@@ -59,6 +59,8 @@ Resources:
     Type: AWS::S3::Bucket
     Properties:
       BucketName: !Ref DemoConfigS3BucketName
+      VersioningConfiguration:
+        Status: Enabled
       BucketEncryption:
         ServerSideEncryptionConfiguration:
           - ServerSideEncryptionByDefault:
@@ -70,6 +72,25 @@ Resources:
         IgnorePublicAcls: true
         BlockPublicPolicy: true
         RestrictPublicBuckets: true
+
+  S3BucketPolicy:
+    Type: AWS::S3::BucketPolicy
+    Properties:
+      Bucket: !Ref S3Bucket
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Action:
+              - 's3:GetObject'
+            Effect: Deny
+            Resource:
+              - !GetAtt 'S3Bucket.Arn'
+              - !Sub '${S3Bucket.Arn}/*'
+            Principal: '*'
+            Condition:
+              Bool:
+                'aws:SecureTransport':
+                  - 'false'
 
   S3PutLambdaRole:
     Type: AWS::IAM::Role


### PR DESCRIPTION
Updating S3 Bucket to enable versioning and enforce TLS encryption on object uploads. Updated EC2 Image Builder cron schedule.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
